### PR TITLE
Add clear button, show solution in grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,23 +7,19 @@
 <body>
     <div class="container">
         <h1>Enter Sudoku</h1>
-        <form method="POST" action="/" onsubmit="showLoading(event);">
+        <form method="POST" action="/" onsubmit="showLoading(event);" autocomplete="off">
             <table>
                 <!-- Python script dynamically fills the rows and cells -->
                 {table_rows}
             </table>
             <input type="submit" value="Solve" id="solveButton">
+            <input type="button" value="Clear" id="clearButton" onclick="clearBoard()">
             <div id="loading" style="display: none;">
                 <div class="spinner"></div>
                 <p>Solving... Please wait.</p>
             </div>
         </form>
-        <div id="solution-container" style="display: none;">
-            <h2>Solution:</h2>
-            <table id="solution-table">
-                <!-- Solution will be inserted here -->
-            </table>
-        </div>
+        <div id="stats" style="display: none;"></div>
     </div>
     <script>
         window.onload = function() {
@@ -79,7 +75,7 @@
                     .then(function(data) {
                         if (data) {
                             console.log('Solution data received:', data);
-                            displaySolution(data.solution, data.original);
+                            displaySolution(data.solution, data.original, data.attempts, data.backtracks);
                         }
                     })
                     .catch(function(error) {
@@ -88,26 +84,26 @@
                     });
             }
 
-            function displaySolution(solution, original) {
+            function displaySolution(solution, original, attempts, backtracks) {
                 console.log('Displaying solution...');
                 document.getElementById('loading').style.display = 'none';
-                document.getElementById('solution-container').style.display = 'block';
-
-                var table = document.getElementById('solution-table');
-                table.innerHTML = '';
 
                 for (var i = 0; i < 9; i++) {
-                    var row = document.createElement('tr');
                     for (var j = 0; j < 9; j++) {
-                        var cell = document.createElement('td');
-                        cell.textContent = solution[i][j];
-                        if (original[i][j] === 0) {
-                            cell.classList.add('solver-filled');
+                        var input = document.querySelector('input[name="cell_' + i + '_' + j + '"]');
+                        if (input) {
+                            input.value = solution[i][j];
+                            if (original[i][j] === 0) {
+                                input.classList.add('solver-filled');
+                            }
                         }
-                        row.appendChild(cell);
                     }
-                    table.appendChild(row);
                 }
+
+                var statsDiv = document.getElementById('stats');
+                statsDiv.textContent = 'Attempts: ' + attempts + ' | Backtracks: ' + backtracks;
+                statsDiv.style.display = 'block';
+                document.getElementById('solveButton').style.display = 'inline-block';
             }
 
             document.addEventListener("keydown", function(e) {
@@ -160,6 +156,15 @@
                     }
                 }
             });
+
+            window.clearBoard = function() {
+                var inputs = document.querySelectorAll('td input[type="text"]');
+                inputs.forEach(function(input) {
+                    input.value = '';
+                    input.classList.remove('solver-filled');
+                });
+                document.getElementById('stats').style.display = 'none';
+            };
         };
     </script>
 </body>

--- a/main,py
+++ b/main,py
@@ -34,7 +34,7 @@ def run_server(shared_state):
                     table_rows += '<tr>'
                     for j in range(9):
                         value = grid[i][j] if grid[i][j] != 0 else ''
-                        table_rows += '<td><input type="text" name="cell_{}_{}" value="{}" maxlength="1"></td>'.format(i, j, value)
+                        table_rows += '<td><input type="text" name="cell_{}_{}" value="{}" maxlength="1" autocomplete="off"></td>'.format(i, j, value)
                     table_rows += '</tr>'
                 # Replace placeholder
                 html = html.replace('{table_rows}', table_rows)
@@ -49,9 +49,12 @@ def run_server(shared_state):
                     self.send_response(200)
                     self.send_header('Content-type', 'application/json')
                     self.end_headers()
+                    stats = shared_state.get('stats', {'attempts': 0, 'backtracks': 0})
                     response = {
                         'solution': shared_state['solution'],
-                        'original': shared_state['grid']
+                        'original': shared_state['grid'],
+                        'attempts': stats.get('attempts', 0),
+                        'backtracks': stats.get('backtracks', 0)
                     }
                     self.wfile.write(json.dumps(response).encode('utf-8'))
                 else:
@@ -103,7 +106,7 @@ def run_server(shared_state):
                 table_rows += '<tr>'
                 for j in range(9):
                     value = grid[i][j] if grid[i][j] != 0 else ''
-                    table_rows += '<td><input type="text" name="cell_{}_{}" value="{}" maxlength="1"></td>'.format(i, j, value)
+                    table_rows += '<td><input type="text" name="cell_{}_{}" value="{}" maxlength="1" autocomplete="off"></td>'.format(i, j, value)
                 table_rows += '</tr>'
             # Replace placeholder
             html = html.replace('{table_rows}', table_rows)
@@ -271,6 +274,7 @@ def main():
     shared_state = manager.dict()
     shared_state['grid'] = [[0]*9 for _ in range(9)]
     shared_state['solution'] = None
+    shared_state['stats'] = {'attempts': 0, 'backtracks': 0}
     shared_state['input_received'] = False
     shared_state['server_failed'] = False
     shared_state['port'] = None
@@ -371,6 +375,10 @@ def main():
         print_grid(solved_grid)
         # Update shared_state with the solution
         shared_state['solution'] = solved_grid
+        shared_state['stats'] = {
+            'attempts': stats['attempts'],
+            'backtracks': stats['backtracks']
+        }
     else:
         print("No solution exists.")
 

--- a/style.css
+++ b/style.css
@@ -84,6 +84,25 @@ input[type="submit"]:hover {
     background-color: #287acc;
 }
 
+input[type="button"] {
+    margin-top: 20px;
+    margin-left: 10px;
+    padding: 12px 24px;
+    font-size: 1.2rem;
+    font-weight: bold;
+    background-color: #cccccc;
+    color: #333;
+    border: none;
+    cursor: pointer;
+    border-radius: 6px;
+    box-shadow: 0 6px 8px rgba(0, 0, 0, 0.2);
+    transition: background-color 0.3s;
+}
+
+input[type="button"]:hover {
+    background-color: #bbbbbb;
+}
+
 table tr:nth-child(3n) td {
     border-bottom: 3px solid #333;
 }
@@ -106,22 +125,12 @@ input[type="text"]::placeholder {
     margin-top: 20px;
 }
 
-#solution-container {
+
+#stats {
     margin-top: 20px;
-}
-
-#solution-table td {
-    width: 60px;
-    height: 60px;
-    border: 1px solid #ddd;
-    text-align: center;
-    font-size: 1.5rem;
-}
-
-#solution-table tr:nth-child(3n) td {
-    border-bottom: 3px solid #333;
-}
-
-#solution-table td:nth-child(3n) {
-    border-right: 3px solid #333;
+    padding: 10px;
+    background-color: #add8e6;
+    color: #333;
+    display: inline-block;
+    border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- add ability to clear the board
- disable form autocompletion
- display the solved puzzle directly in the input grid
- show solving stats with blue background
- send solver statistics from the backend

## Testing
- `python3 -m py_compile main,py`

------
https://chatgpt.com/codex/tasks/task_e_686fa2afc7a4832685a2fac4592a787f