### PR TITLE
Add Sudoku solving animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,31 +95,51 @@
                     });
             }
 
-            function applyGrid(grid, original){
+            function applyGrid(grid, prev, original, highlight){
                 for (var i = 0; i < 9; i++) {
                     for (var j = 0; j < 9; j++) {
                         var input = document.querySelector('input[name="cell_' + i + '_' + j + '"]');
-                        if (input) {
-                            input.value = grid[i][j] || '';
-                            if(original && original[i][j] === 0 && grid[i][j]){
-                                input.parentElement.classList.add('solver-filled');
+                        if (!input) continue;
+                        var cell = input.parentElement;
+                        cell.classList.remove('proposed','changed','removed');
+                        var val = grid[i][j] || '';
+                        input.value = val;
+                        if(highlight && prev){
+                            var prevVal = prev[i][j] || 0;
+                            if(val === ''){
+                                if(prevVal !== 0){
+                                    cell.classList.add('removed');
+                                }
+                            } else {
+                                if(prevVal === 0){
+                                    cell.classList.add('proposed');
+                                } else if(prevVal !== grid[i][j]){
+                                    cell.classList.add('changed');
+                                } else {
+                                    cell.classList.add('proposed');
+                                }
                             }
+                        }
+                        if(original && original[i][j] === 0 && grid[i][j]){
+                            cell.classList.add('solver-filled');
                         }
                     }
                 }
             }
 
-            function animateSteps(steps, callback) {
-                if (!steps || steps.length === 0) { callback(); return; }
+            function animateSteps(steps, original, callback) {
+                if (!steps || steps.length === 0) { callback(original); return; }
                 var index = 0;
                 var delay = 5000 / steps.length;
+                var prev = original;
                 function next() {
                     if (index < steps.length) {
-                        applyGrid(steps[index]);
+                        applyGrid(steps[index], prev, null, true);
+                        prev = steps[index];
                         index++;
                         setTimeout(next, delay);
                     } else {
-                        callback();
+                        callback(prev);
                     }
                 }
                 next();
@@ -128,8 +148,8 @@
             function displaySolution(solution, original, steps) {
                 console.log('Displaying solution...');
                 document.getElementById('loading').style.display = 'none';
-                animateSteps(steps, function(){
-                    applyGrid(solution, original);
+                animateSteps(steps, original, function(last){
+                    applyGrid(solution, last, original, false);
                     var inputs = document.querySelectorAll('input[type="text"]');
                     inputs.forEach(function(inp){ inp.disabled = true; });
                 });

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                     .then(function(data) {
                         if (data) {
                             console.log('Solution data received:', data);
-                            displaySolution(data.solution, data.original);
+                            displaySolution(data.solution, data.original, data.steps);
                         }
                     })
                     .catch(function(error) {
@@ -95,22 +95,44 @@
                     });
             }
 
-            function displaySolution(solution, original) {
-                console.log('Displaying solution...');
-                document.getElementById('loading').style.display = 'none';
-
+            function applyGrid(grid, original){
                 for (var i = 0; i < 9; i++) {
                     for (var j = 0; j < 9; j++) {
                         var input = document.querySelector('input[name="cell_' + i + '_' + j + '"]');
                         if (input) {
-                            input.value = solution[i][j];
-                            input.disabled = true;
-                            if (original[i][j] === 0) {
+                            input.value = grid[i][j] || '';
+                            if(original && original[i][j] === 0 && grid[i][j]){
                                 input.parentElement.classList.add('solver-filled');
                             }
                         }
                     }
                 }
+            }
+
+            function animateSteps(steps, callback) {
+                if (!steps || steps.length === 0) { callback(); return; }
+                var index = 0;
+                var delay = 5000 / steps.length;
+                function next() {
+                    if (index < steps.length) {
+                        applyGrid(steps[index]);
+                        index++;
+                        setTimeout(next, delay);
+                    } else {
+                        callback();
+                    }
+                }
+                next();
+            }
+
+            function displaySolution(solution, original, steps) {
+                console.log('Displaying solution...');
+                document.getElementById('loading').style.display = 'none';
+                animateSteps(steps, function(){
+                    applyGrid(solution, original);
+                    var inputs = document.querySelectorAll('input[type="text"]');
+                    inputs.forEach(function(inp){ inp.disabled = true; });
+                });
             }
 
             document.addEventListener("keydown", function(e) {

--- a/main.py
+++ b/main.py
@@ -51,7 +51,8 @@ def run_server(shared_state):
                     self.end_headers()
                     response = {
                         'solution': shared_state['solution'],
-                        'original': shared_state['grid']
+                        'original': shared_state['grid'],
+                        'steps': shared_state.get('steps', [])
                     }
                     self.wfile.write(json.dumps(response).encode('utf-8'))
                 else:
@@ -68,10 +69,14 @@ def run_server(shared_state):
                 shared_state['grid'] = grid
                 shared_state['solution'] = None
                 shared_state['input_received'] = False
+                shared_state['steps'] = []
                 save_path = os.path.join(script_dir, 'sudoku_save.txt')
                 with open(save_path, 'w') as f:
                     for _ in range(9):
                         f.write('0 0 0 0 0 0 0 0 0\n')
+                steps_path = os.path.join(script_dir, 'sudoku_steps.txt')
+                with open(steps_path, 'w') as f:
+                    pass
                 self.send_response(200)
                 self.end_headers()
                 return
@@ -225,6 +230,31 @@ def count_constraints(grid, row, col, num):
                 count += 1
     return count
 
+def solve_sudoku_steps(grid, steps, step_file):
+    """Recursively solve sudoku while recording each step."""
+    best = find_best_cell(grid)
+    if not best:
+        return True
+    row, col, possible_numbers = best
+    possible_numbers = sorted(possible_numbers, key=lambda n: count_constraints(grid, row, col, n))
+    for num in possible_numbers:
+        if is_valid(grid, row, col, num):
+            grid[row][col] = num
+            snapshot = [r[:] for r in grid]
+            steps.append(snapshot)
+            for r in snapshot:
+                step_file.write(" ".join(map(str, r)) + "\n")
+            step_file.write("\n")
+            if solve_sudoku_steps(grid, steps, step_file):
+                return True
+            grid[row][col] = 0
+            snapshot = [r[:] for r in grid]
+            steps.append(snapshot)
+            for r in snapshot:
+                step_file.write(" ".join(map(str, r)) + "\n")
+            step_file.write("\n")
+    return False
+
 def solve_sudoku(grid, queue=None, progress=None, worker_id=None, stop_event=None, stats=None):
     if stop_event and stop_event.is_set():
         return False
@@ -294,85 +324,31 @@ def display_progress(progress, stop_event):
         print("No solution found.")
 
 def solve_puzzle(shared_state, save_file):
-    """Solve the sudoku in shared_state and store the solution."""
-    grid = shared_state['grid']
-    with open(save_file, 'w') as f:
-        for row in grid:
-            f.write(' '.join(map(str, row)) + '\n')
-    with open(save_file, "r") as f:
-        lines = [line.strip() for line in f.readlines() if line.strip()]
-    grid = [[int(x) for x in line.split()] for line in lines]
-    shared_state["grid"] = [row[:] for row in grid]
+    """Solve the sudoku in shared_state and store the solution with step tracing."""
+    grid = [row[:] for row in shared_state['grid']]
+    steps = []
+    steps_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sudoku_steps.txt')
 
     clear_screen()
     print("Solving the sudoku...")
-    time.sleep(1)
-    start_time = time.time()
+    time_start = time.time()
 
-    manager = Manager()
-    queue = manager.Queue()
-    progress = manager.dict()
-    progress['grid'] = [row[:] for row in grid]
-    stats = manager.dict()
-    stats['attempts'] = 0
-    stats['backtracks'] = 0
-    stop_event = multiprocessing.Event()
+    with open(steps_path, 'w') as step_file:
+        solved = solve_sudoku_steps(grid, steps, step_file)
 
-    empty_cells = []
-    for i in range(9):
-        for j in range(9):
-            if grid[i][j] == 0:
-                possible_numbers = get_possible_numbers(grid, i, j)
-                empty_cells.append((i, j, possible_numbers))
-    empty_cells.sort(key=lambda x: len(x[2]))
-    if not empty_cells:
-        print("Sudoku already solved!")
+    elapsed_time = time.time() - time_start
+
+    if solved:
         shared_state['solution'] = grid
-        return
-
-    num_workers = min(9, multiprocessing.cpu_count(), len(empty_cells))
-    processes = []
-
-    display_thread = threading.Thread(target=display_progress, args=(progress, stop_event))
-    display_thread.start()
-
-    for worker_id in range(num_workers):
-        initial_cell = empty_cells[worker_id]
-        p = multiprocessing.Process(target=worker, args=(
-            grid, queue, progress, worker_id, stop_event, stats, initial_cell))
-        processes.append(p)
-        p.start()
-
-    for p in processes:
-        p.join()
-
-    stop_event.set()
-    display_thread.join()
-
-    end_time = time.time()
-    elapsed_time = end_time - start_time
-
-    clear_screen()
-    if not queue.empty():
-        solved_grid = queue.get()
-        print("Sudoku solved:")
-        print_grid(solved_grid)
-        shared_state['solution'] = solved_grid
-        with open(save_file, "w") as f:
-            for row in solved_grid:
+        with open(save_file, 'w') as f:
+            for row in grid:
                 f.write(" ".join(map(str, row)) + "\n")
-        print("\nSolved grid saved to sudoku_save.txt")
+        print("Sudoku solved in {:.2f} seconds".format(elapsed_time))
     else:
+        shared_state['solution'] = None
         print("No solution exists.")
 
-    print("\nStatistics:")
-    print(f"Time taken: {elapsed_time:.2f} seconds")
-    print(f"Total attempts: {stats['attempts']}")
-    print(f"Total backtracks: {stats['backtracks']}")
-    if stats['attempts'] > 0:
-        print(f"Backtrack ratio: {stats['backtracks']/stats['attempts']:.2f}")
-    else:
-        print("No attempts were made.")
+    shared_state['steps'] = steps
 
 def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -385,6 +361,7 @@ def main():
     shared_state['input_received'] = False
     shared_state['server_failed'] = False
     shared_state['port'] = None
+    shared_state['steps'] = []
 
     # Try to load saved grid
     if os.path.exists(save_file):

--- a/style.css
+++ b/style.css
@@ -112,6 +112,7 @@ input[type="text"]::placeholder {
     padding: 12px 24px;
     font-size: 1.2rem;
     font-weight: bold;
+    display: inline-block;
     background-color: #ff6666;
     color: white;
     border: none;

--- a/style.css
+++ b/style.css
@@ -125,3 +125,6 @@ input[type="text"]::placeholder {
 #clearButton:hover {
     background-color: #cc5252;
 }
+.proposed {background-color: #ccc;}
+.changed {background-color: #66b3ff;}
+.removed {background-color: #ff9999;}


### PR DESCRIPTION
## Summary
- add new `solve_sudoku_steps` recursive solver that records each grid state
- simplify `solve_puzzle` to use the step-tracking solver
- expose recorded steps via the `/solution` endpoint
- clear steps when the grid is cleared
- update page javascript to animate steps over 5 seconds
- tweak Clear button CSS for proper styling

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687521d159dc83269d897977eda91230