### PR TITLE
Improve solver step visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,26 +101,25 @@
                         var input = document.querySelector('input[name="cell_' + i + '_' + j + '"]');
                         if (!input) continue;
                         var cell = input.parentElement;
-                        cell.classList.remove('proposed','changed','removed');
+                        cell.classList.remove('changed','removed','user-input','solver-filled');
                         var val = grid[i][j] || '';
                         input.value = val;
-                        if(highlight && prev){
-                            var prevVal = prev[i][j] || 0;
-                            if(val === ''){
-                                if(prevVal !== 0){
-                                    cell.classList.add('removed');
-                                }
-                            } else {
-                                if(prevVal === 0){
-                                    cell.classList.add('proposed');
+
+                        if(highlight){
+                            if(original && original[i][j] !== 0){
+                                cell.classList.add('user-input');
+                            }
+                            if(prev){
+                                var prevVal = prev[i][j] || 0;
+                                if(val === ''){
+                                    if(prevVal !== 0){
+                                        cell.classList.add('removed');
+                                    }
                                 } else if(prevVal !== grid[i][j]){
                                     cell.classList.add('changed');
-                                } else {
-                                    cell.classList.add('proposed');
                                 }
                             }
-                        }
-                        if(original && original[i][j] === 0 && grid[i][j]){
+                        } else if(original && original[i][j] === 0 && grid[i][j]){
                             cell.classList.add('solver-filled');
                         }
                     }

--- a/style.css
+++ b/style.css
@@ -38,7 +38,7 @@ td {
     height: 60px;
     border: 1px solid #ddd;
     text-align: center;
-    background-color: #f9f9f9;
+    background-color: #ffffff;
 }
 
 input[type="text"] {
@@ -125,6 +125,6 @@ input[type="text"]::placeholder {
 #clearButton:hover {
     background-color: #cc5252;
 }
-.proposed {background-color: #ccc;}
+.user-input {background-color: #e0e0e0;}
 .changed {background-color: #66b3ff;}
 .removed {background-color: #ff9999;}


### PR DESCRIPTION
## Summary
- switch progress indicator to a loading bar
- color code solver steps in the web UI
  - blue for changed values
  - red when a value disappears
  - grey for the user's initial inputs
- default cell background is now white

## Testing
- `python -m py_compile main.py`
- `python main.py` *(terminated after launch to ensure it starts)*

------
https://chatgpt.com/codex/tasks/task_e_68756a85f5e88326a53845043c5c4a74